### PR TITLE
Add MotionLLM documentation and clarify preprocessing pipeline

### DIFF
--- a/CLI.py
+++ b/CLI.py
@@ -249,6 +249,9 @@ def main(
 
     X = ['Video']
 
+    # Build the multimodal encoder and preprocessing utilities that convert raw
+    # video frames into LanguageBind feature sequences before feeding them to the
+    # projection MLP.
     mm_backbone_mlp_model, processor = get_processor(X, args, 'cuda', pretrained_checkpoint_mlp, model_path = 'LanguageBind/Video-LLaVA-7B')
     video_processor = processor['video']
 
@@ -284,6 +287,8 @@ def main(
     while True:
 
         input_video_path = input("\033[0;34;40m Input video path: \033[0m")
+        # The processor handles frame sampling, resizing and normalization so the
+        # downstream towers always receive a tensor shaped (B, C, T, H, W).
         video_tensor = video_processor(input_video_path, return_tensors='pt')['pixel_values']
 
         if type(video_tensor) is list:
@@ -293,6 +298,8 @@ def main(
 
         X_modalities = [tensor,['video']]
 
+        # Encode the preprocessed frames and project them into the language model
+        # hidden size so they can be concatenated with text tokens.
         video_feature = mm_backbone_mlp_model.get_multimodal_embeddings(X_modalities)
 
         prompt = input("\033[0;34;40m Your question: \033[0m")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,30 @@
+# 配置系统说明
+
+MotionLLM 的命令行参数集中在 `options/option.py`，使用 `argparse` 定义训练、推理与多模态组件的超参数集合。【F:options/option.py†L3-L88】
+
+## 数据与路径参数
+- `--prompt`：默认任务描述，用于构造指令模板时的初始文案。【F:options/option.py†L8-L16】
+- `--vqvae_pth`、`--lora_path`、`--mlp_path` 等路径参数用于加载预训练 VQ-VAE、LoRA 适配器与多模态投影器权重。【F:options/option.py†L15-L20】
+- `--data_dir` 设定预处理数据所在目录，以便 `prepare` 与训练脚本统一读取。【F:options/option.py†L15-L20】
+
+## LoRA 与语言模型设置
+- `--lora_r`、`--lora_alpha`、`--lora_dropout` 控制低秩适配层的秩、缩放及 dropout 概率，文件中增加的注释强调了它们和语言模型微调的关系。【F:options/option.py†L23-L28】
+- `--block_size` 指定语言模型的上下文窗口长度，以保证与数据处理中 `max_seq_length` 的兼容性。【F:options/option.py†L30-L31】
+
+## 训练超参数
+- `--batch_size`、`--micro_batch_size`、`--weight_decay`、`--warmup_steps` 等参数用于控制优化器与调度器的行为。【F:options/option.py†L33-L44】
+- `--learning_rate_lora` 与 `--learning_rate_mlp` 分别作用于语言模型 LoRA 层与投影 MLP，允许差异化学习率策略。【F:options/option.py†L33-L39】
+
+## VQ-VAE 与量化设置
+- 代码包含 VQ-VAE 的结构超参，如 `--code_dim`、`--down_t`、`--depth` 等，支持在不同分辨率与码本配置间切换。【F:options/option.py†L46-L58】
+- `--quantizer` 及 `--quantbeta` 控制码本更新策略，适配不同的量化变体。【F:options/option.py†L60-L62】
+
+## 可视化与扩展标志
+- `--render` 与 `--motion_vq_token_path` 用于驱动 SMPL 渲染或载入离线离散化后的动作 token。【F:options/option.py†L64-L66】
+- `--projectionnn`、`--diverse`、`--vinilla` 等标志打开特定的推理模式，如使用多层感知机投影或多样化描述。【F:options/option.py†L72-L74】
+
+## 多模态塔配置
+- `--image_tower` 与 `--video_tower` 决定使用的感知骨干，默认接入 LanguageBind 的图像/视频编码器。【F:options/option.py†L77-L83】
+- `--mm_projector_type`、`--mm_hidden_size`、`--hidden_size` 控制视觉特征如何映射到语言模型的隐藏维度，与多模态投影器构造直接相关。【F:options/option.py†L77-L83】
+
+以上参数在运行 `CLI.py` 或数据处理脚本时通过 `option.get_args_parser()` 统一加载，保证配置的一致性。【F:CLI.py†L31-L32】

--- a/docs/data_processing.md
+++ b/docs/data_processing.md
@@ -1,0 +1,52 @@
+# 数据处理流程说明
+
+## 总览
+MotionLLM 的视频指令数据由 `scripts/video_dataset/prepare_video_dataset_intern_video.py` 与 `prepare_video_dataset_video_llava.py` 负责转换为模型可直接使用的 PyTorch 序列文件。流程包括：
+
+1. 读取原始 JSON 指令、视频路径与回答文本。`json.load` 的结果会被立即转成列表，以保证后续长度统计和迭代顺序的一致性。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L43-L47】【F:scripts/video_dataset/prepare_video_dataset_video_llava.py†L43-L47】
+2. 遍历样本并构造统一的 prompt，拼接回答后送入分词器得到 `input_ids` 和 `labels`。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L85-L111】【F:scripts/video_dataset/prepare_video_dataset_video_llava.py†L85-L111】
+3. 可选地将 prompt 对应的标签位置填入 `IGNORE_INDEX=-1`，使得训练只在回答部分计算损失。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L102-L107】【F:scripts/video_dataset/prepare_video_dataset_video_llava.py†L102-L107】
+4. 将处理后的样本列表保存为 `.pt` 文件，供后续训练/推理直接加载。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L58-L61】【F:scripts/video_dataset/prepare_video_dataset_video_llava.py†L58-L61】
+
+## 输入输出格式示例
+原始 JSON 中的单个样本大致形如：
+
+```json
+{
+  "instruction": "Describe the motion in the clip",
+  "input": "video_samples/sample_0001.mp4",
+  "output": "The person waves and then sits down."
+}
+```
+
+经过 `prepare_sample` 后会得到包含以下关键字段的字典：
+
+```python
+{
+  "instruction": "Describe the motion in the clip",
+  "input": "video_samples/sample_0001.mp4",
+  "output": "The person waves and then sits down.",
+  "sys_command": "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions. ",
+  "input_ids_no_response": tensor([1, 892, 298, ...]),
+  "input_ids": tensor([1, 892, 298, ..., 29871, 13]),
+  "labels": tensor([-1, -1, -1, ..., 29871, 13])
+}
+```
+其中：
+- `input_ids_no_response` 仅包含用户指令部分，构造方式见 `tokenize(tokenizer, full_prompt, eos=False)`。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L90-L91】
+- `input_ids` 在末尾追加了回答文本，并在调用 `tokenize(..., eos=True)` 时自动附加 `<eos>` 标记。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L85-L92】
+- 当 `mask_inputs=True` 时，`labels` 前半段会被填为 `-1` 以忽略用户 prompt。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L102-L107】
+
+## Prompt 模板
+两个脚本都复用了 `generate_prompt_mlp`，当样本包含 `input`（视频路径或描述）时，会生成类似：
+
+```
+A chat between a curious user and an artificial intelligence assistant, paired with an input that provides further context. The assistant gives helpful, detailed, and polite answers to the user's questions. USER: Describe the motion in the clip INPUT_VIDEO: video_samples/sample_0001.mp4.
+ASSISTANT:
+```
+【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L124-L138】
+
+若无输入，则省略 `INPUT_VIDEO` 字段，直接接在 `ASSISTANT:` 后等待模型生成。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L136-L138】
+
+## 数据质量控制
+`prepare` 会针对不同的 `split`（例如 `train_intern_human_2M_stage1_caption` 或 `video_llava_train`）生成对应的 `.pt` 文件，方便后续在不同子任务之间切换。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L152-L157】【F:scripts/video_dataset/prepare_video_dataset_video_llava.py†L175-L180】

--- a/docs/model_architecture.md
+++ b/docs/model_architecture.md
@@ -1,0 +1,29 @@
+# 模型结构与张量形状
+
+## 多模态主干 `LlavaMetaModel`
+`CLI.py` 中的 `LlavaMetaModel` 将 LanguageBind 感知塔与线性投影器组合起来，为语言模型提供视觉前缀特征。【F:CLI.py†L34-L145】
+
+### 视频分支前向流程
+1. 视频预处理后，处理器返回形状为 `(B, C, T, H, W)` 的张量。例如交互式推理阶段读取单个视频时，张量为 `(1, 3, 8, 224, 224)`。【F:CLI.py†L289-L297】
+2. `LanguageBindVideoTower` 将输入映射为 `(B, N, 1024)` 的 token 序列（代码中注释列出了 `torch.Size([1, 2048, 1024])`）。【F:CLI.py†L135-L139】
+3. `mm_projector` 再把视觉 token 投射到语言模型隐藏维度 `(B, N, 4096)`，为后续与文本 token 融合做好准备。【F:CLI.py†L135-L139】
+4. `get_multimodal_embeddings` 根据模态关键字动态调用 `encode_videos` 或 `encode_images`，统一输出视觉特征序列。【F:CLI.py†L141-L145】
+
+### 感知塔构建
+`models/multimodal_encoder/builder.py` 根据配置名称选择具体骨干：
+- 图像塔根据路径前缀在 CLIP、LanguageBind 或 MAE 实现之间切换。【F:models/multimodal_encoder/builder.py†L7-L21】
+- 视频塔默认使用 `LanguageBind_Video_merge`，其输出形状为 `(batch, frames * patches, hidden)`，随后由多模态投影器完成维度匹配。【F:models/multimodal_encoder/builder.py†L23-L30】
+
+## 文本生成模型
+- `GPT` 来自 `lit_gpt.lora`，在加载基础 Vicuna 权重后，附加 LoRA 模块以降低微调成本。【F:CLI.py†L8-L27】【F:CLI.py†L222-L245】
+- 视觉投影器的权重与 LoRA 权重一起合并进语言模型，使得 `(N, 4096)` 的视觉嵌入可以与 tokenizer 输出的 `(T, 4096)` 文本隐藏状态串接。【F:CLI.py†L260-L313】
+
+## 关键形状总结
+| 阶段 | 形状 | 说明 |
+| --- | --- | --- |
+| 视频处理器输出 | `(B, C, T, H, W)` | 通过 `video_processor` 完成归一化与采样。【F:CLI.py†L289-L297】 |
+| 视频塔输出 | `(B, N, 1024)` | LanguageBind 视频编码器提取的时空特征。【F:CLI.py†L135-L139】 |
+| 多模态投影输出 | `(B, N, 4096)` | 对齐 Vicuna 隐藏维度，便于拼接文本 tokens。【F:CLI.py†L135-L139】 |
+| 文本 token 序列 | `(1, T)` | 由 tokenizer 编码 prompt 与回答。【F:CLI.py†L308-L327】【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L85-L111】 |
+
+视觉序列最终通过 `generate` 函数与文本 tokens 一同送入语言模型，完成跨模态的回答生成。【F:CLI.py†L317-L331】

--- a/docs/training_inference.md
+++ b/docs/training_inference.md
@@ -1,0 +1,27 @@
+# 训练与推理流水线
+
+## 数据准备阶段
+1. 调用 `scripts/video_dataset/prepare_*.py`，将原始 JSON 样本转成 `input_ids`、`labels` 等张量并保存为 `.pt` 文件。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L23-L111】【F:scripts/video_dataset/prepare_video_dataset_video_llava.py†L23-L111】
+2. 标签前缀被置为 `IGNORE_INDEX`，训练时只回传回答部分的梯度，避免模型“抄题”。【F:scripts/video_dataset/prepare_video_dataset_intern_video.py†L102-L107】
+
+## 配置加载
+- `option.get_args_parser()` 在 `CLI.py` 启动时立即解析所有路径与超参数，保证训练、推理脚本使用一致配置。【F:CLI.py†L31-L32】
+- 其中包含 LoRA、VQ-VAE、多模态塔等模块的关键超参，详见《配置系统说明》。【F:options/option.py†L8-L88】
+
+## 模型与权重初始化
+1. 通过 `EmptyInitOnDevice` 与 `lora(...)` 上下文构建 Vicuna 基座，并启用 LoRA 低秩适配结构。【F:CLI.py†L222-L245】
+2. 加载三类权重：Vicuna 预训练模型、LoRA 增量权重以及视觉投影器（MLP），随后将其合并。【F:CLI.py†L260-L273】
+3. `get_processor` 根据配置创建 LanguageBind 感知塔和对应的预处理器，用于在 GPU 上提取视频特征。【F:CLI.py†L147-L170】
+
+## 推理 Pipeline
+1. 用户提供视频路径后，`video_processor` 完成采样与归一化，输出 `(B, C, T, H, W)` 的张量。【F:CLI.py†L289-L297】
+2. `LlavaMetaModel` 将视频张量编码为 `(B, N, 1024)`，再经 `mm_projector` 投影到语言模型维度 `(B, N, 4096)`。【F:CLI.py†L135-L145】
+3. 根据用户问题构造文本 prompt，并与视觉特征一起组织成 `generate` 所需的元组输入。【F:CLI.py†L305-L326】
+4. `generate` 函数逐 token 采样，支持温度与 top-k 调节；当采样到 `<eos>` 或达到最大步数时终止。【F:generate.py†L14-L108】
+5. 最终输出经过 tokenizer 解码并展示给用户。【F:CLI.py†L327-L331】
+
+## 训练思路
+虽然仓库中未包含完整的训练脚本，但利用生成的 `.pt` 数据与 LoRA 配置，可复用 `lit_gpt` 的训练循环：
+1. 构建 `DataLoader` 读取 `.pt` 样本，使用 `input_ids` 与 `labels` 进行监督微调。
+2. 只对 LoRA 参数和多模态投影器求梯度，保证基础模型稳定。【F:CLI.py†L222-L273】
+3. 在评估阶段复用上述推理流水线，检验模型对视频问题的回答质量。

--- a/models/multimodal_encoder/builder.py
+++ b/models/multimodal_encoder/builder.py
@@ -23,6 +23,9 @@ def build_image_tower(image_tower_cfg, **kwargs):
 def build_video_tower(video_tower_cfg, **kwargs):
     video_tower = getattr(video_tower_cfg, 'mm_video_tower', getattr(video_tower_cfg, 'video_tower', None))
     if video_tower.endswith('LanguageBind_Video_merge'):
+        # LanguageBind's merged video tower returns a feature map shaped
+        # (batch, frames * patches, hidden) which is later projected into the
+        # language model width by the multimodal projector.
         return LanguageBindVideoTower(video_tower, args=video_tower_cfg, cache_dir='./cache_dir', **kwargs)
     raise ValueError(f'Unknown video tower: {video_tower}')
 

--- a/options/option.py
+++ b/options/option.py
@@ -6,6 +6,8 @@ def get_args_parser():
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     ## dataloader
+    # Prompt text that seeds instruction templates when no explicit CLI input is
+    # provided.
     parser.add_argument('--prompt', type=str, default="Generate a textual description corresponding to the given sequence of human motion tokens.", help='task description')
     parser.add_argument('--input', type=str, help='generation condictions')
     parser.add_argument('--dataname', type=str, default='t2m', help='dataset directory')
@@ -19,6 +21,8 @@ def get_args_parser():
 
 
     ## lora
+    # LoRA hyper-parameters controlling rank, scaling and dropout used in
+    # low-rank adaptation of the language model weights.
     parser.add_argument('--lora_r', type=int, default=64)
     parser.add_argument('--lora_alpha', type=int, default=16)
     parser.add_argument('--lora_dropout', type=float, default=0.05)

--- a/scripts/video_dataset/prepare_video_dataset_intern_video.py
+++ b/scripts/video_dataset/prepare_video_dataset_intern_video.py
@@ -42,6 +42,8 @@ def prepare(
 
     with open(file_path, "r") as file:
         data = json.load(file)
+    # Materialize the json iterator into a list so that shuffling or length
+    # queries behave the same across different python versions.
     data_set = list(data)
 
     print(f"{split} set has {len(data_set):,} samples")
@@ -81,6 +83,8 @@ def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_in
     # full_prompt = generate_prompt(example)
     # import pdb; pdb.set_trace()
     full_prompt = generate_prompt_mlp(example)
+    # Concatenate the golden answer so that the tokenizer observes a complete
+    # dialogue turn when constructing the training labels.
     full_prompt_and_response = full_prompt + example['output']
     # import pdb; pdb.set_trace()
     encoded_full_prompt = tokenize(tokenizer, full_prompt, max_length=max_length, eos=False)
@@ -98,6 +102,8 @@ def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_in
     # The labels are the full prompt with response, but with the prompt masked out
     labels = encoded_full_prompt_and_response.clone()
     if mask_inputs:
+        # Ignore the instruction tokens when computing the loss so the model is
+        # only supervised on the expected assistant reply.
         labels[:len(encoded_full_prompt)] = IGNORE_INDEX
 
     # import pdb; pdb.set_trace()

--- a/scripts/video_dataset/prepare_video_dataset_video_llava.py
+++ b/scripts/video_dataset/prepare_video_dataset_video_llava.py
@@ -42,6 +42,8 @@ def prepare(
 
     with open(file_path, "r") as file:
         data = json.load(file)
+    # The raw json loader can be a generator, so explicitly materialize a list
+    # to make downstream length checks and indexing deterministic.
     data_set = list(data)
 
     print(f"{split} set has {len(data_set):,} samples")
@@ -81,6 +83,8 @@ def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_in
     # full_prompt = generate_prompt(example)
     # import pdb; pdb.set_trace()
     full_prompt = generate_prompt_mlp(example)
+    # Concatenate the assistant's answer so the tokenizer can create labels that
+    # align with the generated response tokens.
     full_prompt_and_response = full_prompt + example['output']
     
     encoded_full_prompt = tokenize(tokenizer, full_prompt, max_length=max_length, eos=False)
@@ -98,6 +102,8 @@ def prepare_sample(example: dict, tokenizer: Tokenizer, max_length: int, mask_in
     # The labels are the full prompt with response, but with the prompt masked out
     labels = encoded_full_prompt_and_response.clone()
     if mask_inputs:
+        # Mask out the instruction tokens so the loss is only applied on the
+        # response portion during supervised fine-tuning.
         labels[:len(encoded_full_prompt)] = IGNORE_INDEX
 
     # import pdb; pdb.set_trace()


### PR DESCRIPTION
## Summary
- create a docs/ directory with focused guides covering data preparation, configuration, model tensor shapes, and the training/inference pipeline
- annotate key preprocessing, configuration, and multimodal integration code paths to highlight data/feature flow assumptions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb892bdb0483208b12fa58d5fa3c61